### PR TITLE
Fiks versjonshistorikken i HTML-view

### DIFF
--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -16,12 +16,10 @@ const getDefaultView = (isWebpage: boolean, hasAttachment: boolean): ViewVariant
 export const Content = () => {
     const { selectedContentId, selectedLocale, selectedVersion } = useAppState();
 
-    const fetchId = selectedVersion?.nodeId || selectedContentId;
-
     const { data, isLoading } = useFetchContent({
-        id: fetchId || '',
+        id: selectedContentId ?? '',
         locale: selectedLocale,
-        versionId: selectedVersion?.versionId ?? undefined,
+        versionId: selectedVersion ?? '',
     });
 
     const isWebpage = !!data?.html && !data.json.attachment;

--- a/xp-archive/client/contentTree/contentTreeEntry/NavigationItem.tsx
+++ b/xp-archive/client/contentTree/contentTreeEntry/NavigationItem.tsx
@@ -13,8 +13,8 @@ type Props = {
 export const getContentIconUrl = (type: string) =>
     `${import.meta.env.VITE_APP_ORIGIN}/xp/api/contentIcon?type=${type}`;
 
-export const updateContentUrl = (id: string, locale: string) => {
-    const newUrl = `${xpArchiveConfig.basePath}/${id}/${locale}`;
+export const updateContentUrl = (nodeId: string, locale: string, versionId?: string) => {
+    const newUrl = `${xpArchiveConfig.basePath}/${nodeId}/${locale}/${versionId ?? ''}`;
     window.history.pushState({}, '', newUrl);
 };
 

--- a/xp-archive/client/contentView/ContentView.tsx
+++ b/xp-archive/client/contentView/ContentView.tsx
@@ -11,7 +11,7 @@ import style from './ContentView.module.css';
 const getDisplayComponent = (viewVariant: ViewVariant, data?: ContentServiceResponse | null) => {
     if (!data) return null;
     const components: Record<ViewVariant, React.ReactElement> = {
-        html: <HtmlView versionId={data.json._id} locale={data.json.language} />,
+        html: <HtmlView nodeId={data.json._id} locale={data.json.language} />,
         filepreview: <FilePreviewWrapper content={data.json} />,
         pdf: <PdfExport versions={data.versions} />,
     };

--- a/xp-archive/client/contentView/ContentView.tsx
+++ b/xp-archive/client/contentView/ContentView.tsx
@@ -11,7 +11,13 @@ import style from './ContentView.module.css';
 const getDisplayComponent = (viewVariant: ViewVariant, data?: ContentServiceResponse | null) => {
     if (!data) return null;
     const components: Record<ViewVariant, React.ReactElement> = {
-        html: <HtmlView nodeId={data.json._id} locale={data.json.language} />,
+        html: (
+            <HtmlView
+                nodeId={data.json._id}
+                locale={data.json.language}
+                versionId={data.json._versionKey}
+            />
+        ),
         filepreview: <FilePreviewWrapper content={data.json} />,
         pdf: <PdfExport versions={data.versions} />,
     };

--- a/xp-archive/client/contentView/htmlView/HtmlView.tsx
+++ b/xp-archive/client/contentView/htmlView/HtmlView.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export const HtmlView = ({ nodeId, locale, versionId }: Props) => {
     const [isLoading, setIsLoading] = useState(true);
-    const htmlPath = `${xpArchiveConfig.basePath}/html/${nodeId}/${locale || ''}/${versionId || ''}`;
+    const htmlPath = `${xpArchiveConfig.basePath}/html/${nodeId}/${locale}/${versionId}`;
 
     return (
         <div className={style.wrapper}>

--- a/xp-archive/client/contentView/htmlView/HtmlView.tsx
+++ b/xp-archive/client/contentView/htmlView/HtmlView.tsx
@@ -5,13 +5,13 @@ import { xpArchiveConfig } from '@common/shared/siteConfigs';
 import { Button, Loader } from '@navikt/ds-react';
 
 type Props = {
-    versionId: string;
+    nodeId: string;
     locale: string;
 };
 
-export const HtmlView = ({ versionId, locale }: Props) => {
+export const HtmlView = ({ nodeId, locale }: Props) => {
     const [isLoading, setIsLoading] = useState(true);
-    const htmlPath = `${xpArchiveConfig.basePath}/html/${versionId}/${locale || ''}`;
+    const htmlPath = `${xpArchiveConfig.basePath}/html/${nodeId}/${locale || ''}`;
 
     return (
         <div className={style.wrapper}>

--- a/xp-archive/client/contentView/htmlView/HtmlView.tsx
+++ b/xp-archive/client/contentView/htmlView/HtmlView.tsx
@@ -7,11 +7,12 @@ import { Button, Loader } from '@navikt/ds-react';
 type Props = {
     nodeId: string;
     locale: string;
+    versionId: string;
 };
 
-export const HtmlView = ({ nodeId, locale }: Props) => {
+export const HtmlView = ({ nodeId, locale, versionId }: Props) => {
     const [isLoading, setIsLoading] = useState(true);
-    const htmlPath = `${xpArchiveConfig.basePath}/html/${nodeId}/${locale || ''}`;
+    const htmlPath = `${xpArchiveConfig.basePath}/html/${nodeId}/${locale || ''}/${versionId || ''}`;
 
     return (
         <div className={style.wrapper}>

--- a/xp-archive/client/context/appState/AppStateContext.ts
+++ b/xp-archive/client/context/appState/AppStateContext.ts
@@ -1,5 +1,4 @@
 import { createContext } from 'react';
-import { SelectedVersion } from './AppStateProvider';
 import { Locale } from 'client/contentTree/NavigationBar';
 
 export type AppState = {
@@ -7,8 +6,8 @@ export type AppState = {
     setSelectedContentId: (contentId: string) => void;
     selectedLocale: Locale;
     setSelectedLocale: (locale: Locale) => void;
-    selectedVersion?: SelectedVersion;
-    setSelectedVersion: (selectedVersion: SelectedVersion | undefined) => void;
+    selectedVersion?: string;
+    setSelectedVersion: (versionId: string) => void;
 };
 
 export const AppStateContext = createContext<AppState>({

--- a/xp-archive/client/context/appState/AppStateProvider.tsx
+++ b/xp-archive/client/context/appState/AppStateProvider.tsx
@@ -6,15 +6,10 @@ type Props = {
     children: React.ReactNode;
 };
 
-export type SelectedVersion = {
-    versionId: string;
-    nodeId?: string;
-};
-
 export const AppStateProvider = ({ children }: Props) => {
     const [selectedContentId, setSelectedContentId] = useState<string>();
     const [selectedLocale, setSelectedLocale] = useState<Locale>('no');
-    const [selectedVersion, setSelectedVersion] = useState<SelectedVersion>();
+    const [selectedVersion, setSelectedVersion] = useState<string>();
 
     useEffect(() => {
         const path = window.location.pathname;

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -21,14 +21,19 @@ type Props = {
 };
 
 export const VersionSelector = ({ versions }: Props) => {
-    const { selectedContentId, setSelectedContentId, selectedVersion, setSelectedVersion } =
-        useAppState();
+    const {
+        selectedContentId,
+        setSelectedContentId,
+        selectedVersion,
+        setSelectedVersion,
+        selectedLocale,
+    } = useAppState();
 
     const selectVersion = (e: ChangeEvent<HTMLSelectElement>) => {
         const versionId = e.target.value;
         const nodeId = versions.find((v) => v.versionId === versionId)?.nodeId;
         if (nodeId) setSelectedContentId(nodeId);
-        updateContentUrl(selectedContentId ?? '', 'no', versionId); // TODO: fiks hardkodet locale
+        updateContentUrl(selectedContentId ?? '', selectedLocale, versionId);
         setSelectedVersion(versionId);
     };
 

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -21,16 +21,15 @@ type Props = {
 };
 
 export const VersionSelector = ({ versions }: Props) => {
-    const { selectedVersion, setSelectedVersion } = useAppState();
+    const { selectedContentId, setSelectedContentId, selectedVersion, setSelectedVersion } =
+        useAppState();
 
     const selectVersion = (e: ChangeEvent<HTMLSelectElement>) => {
-        if (!e.target.value) {
-            setSelectedVersion(undefined);
-        }
         const versionId = e.target.value;
         const nodeId = versions.find((v) => v.versionId === versionId)?.nodeId;
-        setSelectedVersion({ nodeId, versionId });
-        updateContentUrl(nodeId ?? '', 'no', versionId); // TODO: fiks hardkodet locale
+        if (nodeId) setSelectedContentId(nodeId);
+        updateContentUrl(selectedContentId ?? '', 'no', versionId); // TODO: fiks hardkodet locale
+        setSelectedVersion(versionId);
     };
 
     // const selectVersionC = (versionId: string) => {
@@ -50,11 +49,7 @@ export const VersionSelector = ({ versions }: Props) => {
                 options={getOptions(versions)}
                 clearButton={false}
             ></UNSAFE_Combobox> */}
-            <Select
-                label={'Versjoner'}
-                onChange={selectVersion}
-                value={selectedVersion?.versionId ?? ''}
-            >
+            <Select label={'Versjoner'} onChange={selectVersion} value={selectedVersion ?? ''}>
                 <option value={''}>Siste versjon</option>
                 {versions.map((version) => (
                     <option key={version.versionId} value={version.versionId}>

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -4,6 +4,7 @@ import { VersionReference } from 'shared/types';
 import { pruneString } from '@common/shared/pruneString';
 import { formatTimestamp } from '@common/shared/timestamp';
 import { useAppState } from 'client/context/appState/useAppState';
+import { updateContentUrl } from 'client/contentTree/contentTreeEntry/NavigationItem';
 
 // function getOptions(versions: VersionReference[]): { label: string; value: string }[] {
 //     const sisteVersjon = { label: 'Siste versjon', value: 'Siste versjon' };
@@ -29,6 +30,7 @@ export const VersionSelector = ({ versions }: Props) => {
         const versionId = e.target.value;
         const nodeId = versions.find((v) => v.versionId === versionId)?.nodeId;
         setSelectedVersion({ nodeId, versionId });
+        updateContentUrl(nodeId ?? '', 'no', versionId); // TODO: fiks hardkodet locale
     };
 
     // const selectVersionC = (versionId: string) => {

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -6,16 +6,6 @@ import { formatTimestamp } from '@common/shared/timestamp';
 import { useAppState } from 'client/context/appState/useAppState';
 import { updateContentUrl } from 'client/contentTree/contentTreeEntry/NavigationItem';
 
-// function getOptions(versions: VersionReference[]): { label: string; value: string }[] {
-//     const sisteVersjon = { label: 'Siste versjon', value: 'Siste versjon' };
-
-//     const mapVersionToOption = versions.map((v) => ({
-//         label: `${formatTimestamp(v.timestamp)} - ${pruneString(v.displayName, 100)}`,
-//         value: v.versionId,
-//     }));
-//     return [sisteVersjon, ...mapVersionToOption];
-// }
-
 type Props = {
     versions: VersionReference[];
 };
@@ -37,31 +27,14 @@ export const VersionSelector = ({ versions }: Props) => {
         setSelectedVersion(versionId);
     };
 
-    // const selectVersionC = (versionId: string) => {
-    //     if (!versionId) {
-    //         setSelectedVersion(undefined);
-    //     }
-    //     const nodeId = versions.find((v) => v.versionId === versionId)?.nodeId;
-    //     setSelectedVersion({ nodeId, versionId });
-    // };
     return (
-        <>
-            {/* <UNSAFE_Combobox
-                label={'Versjoner'}
-                onChange={selectVersionC}
-                value={selectedVersion?.versionId ?? 'Siste versjon'}
-                shouldAutocomplete={true}
-                options={getOptions(versions)}
-                clearButton={false}
-            ></UNSAFE_Combobox> */}
-            <Select label={'Versjoner'} onChange={selectVersion} value={selectedVersion ?? ''}>
-                <option value={''}>Siste versjon</option>
-                {versions.map((version) => (
-                    <option key={version.versionId} value={version.versionId}>
-                        {`${formatTimestamp(version.timestamp)} - ${pruneString(version.displayName, 100)}`}
-                    </option>
-                ))}
-            </Select>
-        </>
+        <Select label={'Versjoner'} onChange={selectVersion} value={selectedVersion ?? ''}>
+            <option value={''}>Siste versjon</option>
+            {versions.map((version) => (
+                <option key={version.versionId} value={version.versionId}>
+                    {`${formatTimestamp(version.timestamp)} - ${pruneString(version.displayName, 100)}`}
+                </option>
+            ))}
+        </Select>
     );
 };

--- a/xp-archive/server/src/routing/site.ts
+++ b/xp-archive/server/src/routing/site.ts
@@ -49,10 +49,10 @@ const setupApiRoutes = async (router: Router) => {
 const setupBrowserRoutes = async (router: Router, htmlRenderer: HtmlRenderer) => {
     const contentService = new ContentService();
 
-    router.get('/html/:contentId/:locale', async (req, res, next) => {
-        const { contentId, locale } = req.params;
+    router.get('/html/:contentId/:locale/:versionId', async (req, res, next) => {
+        const { contentId, locale, versionId } = req.params;
 
-        const content = await contentService.fetchContent(contentId, locale);
+        const content = await contentService.fetchContent(contentId, locale, versionId);
         if (!content) {
             return next();
         }
@@ -64,10 +64,10 @@ const setupBrowserRoutes = async (router: Router, htmlRenderer: HtmlRenderer) =>
         return res.send(content.html);
     });
 
-    router.get('/:contentId/:locale', async (req, res, next) => {
-        const { contentId, locale } = req.params;
+    router.get('/:contentId/:locale/:versionId', async (req, res, next) => {
+        const { contentId, locale, versionId } = req.params;
 
-        const content = await contentService.fetchContent(contentId, locale);
+        const content = await contentService.fetchContent(contentId, locale, versionId);
         if (!content) {
             return next();
         }


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Fikser så valgt versjon vises som HTML, ikke bare siste versjon uansett. 

Oppdaterer også URLen med riktig versjon, og fikser så riktig versjon åpnes når man åpner en url som inneholder versionId (f.eks. https://cms-arkiv.ansatt.dev.nav.no/xp/baf59cae-6de9-48fb-b8fb-4d873a275112/en/025ab3d0-52e8-41a8-b91b-cc40010d4c3a)

## Testing

Har testet selv i dev
