### PR TITLE
Fiks URL-håndtering (alltid versjonsID)

### DIFF
--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -56,6 +56,15 @@ export const Content = () => {
         setSelectedView(getDefaultView(isWebpage, hasAttachment));
     }, [isWebpage, hasAttachment, selectedContentId]);
 
+    const getVersionDisplay = () => {
+        if (selectedVersion && data?.versions) {
+            return formatTimestamp(
+                data.versions.find((v) => v.versionId === selectedVersion)?.timestamp ?? ''
+            );
+        }
+        return 'Laster...';
+    };
+
     if (!selectedContentId) {
         return <EmptyState />;
     }
@@ -84,14 +93,7 @@ export const Content = () => {
                         iconPosition={'right'}
                         onClick={() => setIsVersionPanelOpen(true)}
                     >
-                        {selectedVersion && data?.versions
-                            ? formatTimestamp(
-                                  data.versions.find((v) => v.versionId === selectedVersion)
-                                      ?.timestamp ?? ''
-                              )
-                            : data?.versions?.[0]
-                              ? `${formatTimestamp(data.versions[0].timestamp, true)} (Siste versjon)`
-                              : 'Laster...'}
+                        {getVersionDisplay()}
                     </Button>
                     <VersionSelector
                         versions={data?.versions || []}

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -48,8 +48,8 @@ export const Content = () => {
             updateContentUrl(selectedContentId ?? '', selectedLocale, selectedVersion);
         } else if (data?.versions?.[0]) {
             const latestVersionId = data.versions[0].versionId;
-            updateContentUrl(selectedContentId ?? '', selectedLocale, latestVersionId);
             setSelectedVersion(latestVersionId);
+            updateContentUrl(selectedContentId ?? '', selectedLocale, latestVersionId);
         }
     }, [data, selectedContentId, selectedLocale, selectedVersion]);
 

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -27,6 +27,7 @@ export const Content = () => {
     const { selectedContentId, selectedLocale, selectedVersion, setSelectedVersion } =
         useAppState();
 
+    //TODO: skal denne bort eller endres noe?
     useEffect(() => {
         const pathSegments = window.location.pathname.split('/');
         if (pathSegments.length >= 5) {
@@ -43,7 +44,9 @@ export const Content = () => {
     });
 
     useEffect(() => {
-        if (data?.versions?.[0] && !selectedVersion) {
+        if (selectedVersion) {
+            updateContentUrl(selectedContentId ?? '', selectedLocale, selectedVersion);
+        } else if (data?.versions?.[0]) {
             const latestVersionId = data.versions[0].versionId;
             updateContentUrl(selectedContentId ?? '', selectedLocale, latestVersionId);
             setSelectedVersion(latestVersionId);

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { SidebarRightIcon } from '@navikt/aksel-icons';
+import { xpArchiveConfig } from '@common/shared/siteConfigs';
 import { Button, Detail, Heading, Label } from '@navikt/ds-react';
 import { useFetchContent } from '../hooks/useFetchContent';
 import { useAppState } from '../context/appState/useAppState';
 import { ViewSelector, ViewVariant } from 'client/viewSelector/ViewSelector';
 import { VersionSelector } from 'client/versionSelector/VersionSelector';
-import { updateContentUrl } from 'client/contentTree/contentTreeEntry/NavigationItem';
 import { ContentView } from '../contentView/ContentView';
 import { formatTimestamp } from '@common/shared/timestamp';
 import { EmptyState } from '@common/shared/EmptyState/EmptyState';
@@ -16,6 +16,11 @@ const getDefaultView = (isWebpage: boolean, hasAttachment: boolean): ViewVariant
     if (isWebpage) return 'html';
     if (hasAttachment) return 'filepreview';
     return undefined;
+};
+
+const updateContentUrl = (nodeId: string, locale: string, versionId?: string) => {
+    const newUrl = `${xpArchiveConfig.basePath}/${nodeId}/${locale}/${versionId ?? ''}`;
+    window.history.pushState({}, '', newUrl);
 };
 
 export const Content = () => {

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -27,7 +27,6 @@ export const Content = () => {
     const { selectedContentId, selectedLocale, selectedVersion, setSelectedVersion } =
         useAppState();
 
-    //TODO: skal denne bort eller endres noe?
     useEffect(() => {
         const pathSegments = window.location.pathname.split('/');
         if (pathSegments.length >= 5) {

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -5,6 +5,7 @@ import { useFetchContent } from '../hooks/useFetchContent';
 import { useAppState } from '../context/appState/useAppState';
 import { ViewSelector, ViewVariant } from 'client/viewSelector/ViewSelector';
 import { VersionSelector } from 'client/versionSelector/VersionSelector';
+import { updateContentUrl } from 'client/contentTree/contentTreeEntry/NavigationItem';
 import { ContentView } from '../contentView/ContentView';
 import { formatTimestamp } from '@common/shared/timestamp';
 import { EmptyState } from '@common/shared/EmptyState/EmptyState';
@@ -35,6 +36,14 @@ export const Content = () => {
         locale: selectedLocale,
         versionId: selectedVersion ?? '',
     });
+
+    useEffect(() => {
+        if (data?.versions?.[0] && !selectedVersion) {
+            const latestVersionId = data.versions[0].versionId;
+            updateContentUrl(selectedContentId ?? '', selectedLocale, latestVersionId);
+            setSelectedVersion(latestVersionId);
+        }
+    }, [data, selectedContentId, selectedLocale, selectedVersion]);
 
     const isWebpage = !!data?.html && !data.json.attachment;
     const hasAttachment = !!data?.json.attachment;

--- a/xp-archive/client/contentTree/contentTreeEntry/NavigationItem.tsx
+++ b/xp-archive/client/contentTree/contentTreeEntry/NavigationItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ContentTreeEntryData } from '../../../shared/types';
-import { xpArchiveConfig } from '@common/shared/siteConfigs';
 import { useAppState } from '../../context/appState/useAppState';
 import { TreeItem } from '@mui/x-tree-view';
 import { useContentTree } from 'client/hooks/useContentTree';
@@ -12,11 +11,6 @@ type Props = {
 
 export const getContentIconUrl = (type: string) =>
     `${import.meta.env.VITE_APP_ORIGIN}/xp/api/contentIcon?type=${type}`;
-
-export const updateContentUrl = (nodeId: string, locale: string, versionId?: string) => {
-    const newUrl = `${xpArchiveConfig.basePath}/${nodeId}/${locale}/${versionId ?? ''}`;
-    window.history.pushState({}, '', newUrl);
-};
 
 export const NavigationItem = ({ entry }: Props) => {
     const { setSelectedContentId } = useAppState();

--- a/xp-archive/client/contentTree/contentTreeEntry/NavigationItem.tsx
+++ b/xp-archive/client/contentTree/contentTreeEntry/NavigationItem.tsx
@@ -39,7 +39,6 @@ export const NavigationItem = ({ entry }: Props) => {
     const onClick = () => {
         if (!entry.isEmpty) {
             setSelectedContentId(entry.id);
-            updateContentUrl(entry.id, entry.locale);
         }
     };
 

--- a/xp-archive/client/contentTree/search/SearchResultItem/SearchResultItem.tsx
+++ b/xp-archive/client/contentTree/search/SearchResultItem/SearchResultItem.tsx
@@ -1,9 +1,6 @@
 import { BodyShort, Detail } from '@navikt/ds-react';
 import { classNames } from '@common/client/utils/classNames';
-import {
-    updateContentUrl,
-    getContentIconUrl,
-} from 'client/contentTree/contentTreeEntry/NavigationItem';
+import { getContentIconUrl } from 'client/contentTree/contentTreeEntry/NavigationItem';
 import { useAppState } from 'client/context/appState/useAppState';
 import { SearchResponse } from 'shared/types';
 
@@ -31,7 +28,6 @@ export const SearchResultItem = ({
             onClick={() => {
                 setSelectedContentId(hit._id);
                 setSelectedLocale(hit.layerLocale);
-                updateContentUrl(hit._id, hit.layerLocale);
             }}
         >
             <img

--- a/xp-archive/client/versionSelector/VersionSelector.module.css
+++ b/xp-archive/client/versionSelector/VersionSelector.module.css
@@ -11,6 +11,7 @@
 
     :global(.navds-label) {
         font-weight: var(--a-font-weight-regular);
+        text-align: left;
     }
 
     :global(.navds-button__icon) {

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -73,13 +73,16 @@ export const VersionSelector = ({ versions, isOpen, onClose }: Props) => {
                 className={style.search}
             />
             <div className={style.versionList}>
-                {filteredVersions.map((version) => (
+                {filteredVersions.map((version, index) => (
                     <VersionButton
                         key={version.versionId}
                         isSelected={version.versionId === selectedVersion}
                         onClick={() => selectVersion(version.versionId)}
                     >
                         {formatTimestamp(version.timestamp)}
+                        {index === 0 && (
+                            <span style={{ fontWeight: 'normal' }}> (Siste versjon)</span>
+                        )}
                     </VersionButton>
                 ))}
             </div>

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -73,16 +73,6 @@ export const VersionSelector = ({ versions, isOpen, onClose }: Props) => {
                 className={style.search}
             />
             <div className={style.versionList}>
-                <VersionButton isSelected={!selectedVersion} onClick={() => selectVersion('')}>
-                    {versions[0] ? (
-                        <>
-                            {formatTimestamp(versions[0].timestamp, true)}
-                            <span style={{ fontWeight: 'normal' }}> (Siste versjon)</span>
-                        </>
-                    ) : (
-                        'Laster...'
-                    )}
-                </VersionButton>
                 {filteredVersions.map((version) => (
                     <VersionButton
                         key={version.versionId}

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -3,7 +3,6 @@ import { Heading, Button, Search } from '@navikt/ds-react';
 import { VersionReference } from 'shared/types';
 import { formatTimestamp } from '@common/shared/timestamp';
 import { useAppState } from 'client/context/appState/useAppState';
-import { updateContentUrl } from 'client/contentTree/contentTreeEntry/NavigationItem';
 import { SlidePanel } from './SlidePanel/SlidePanel';
 import { classNames } from '@common/client/utils/classNames';
 import style from './VersionSelector.module.css';
@@ -35,13 +34,7 @@ const VersionButton = ({ isSelected, onClick, children }: VersionButtonProps) =>
 
 export const VersionSelector = ({ versions, isOpen, onClose }: Props) => {
     const [searchQuery, setSearchQuery] = useState('');
-    const {
-        selectedContentId,
-        setSelectedContentId,
-        selectedVersion,
-        setSelectedVersion,
-        selectedLocale,
-    } = useAppState();
+    const { setSelectedContentId, selectedVersion, setSelectedVersion } = useAppState();
 
     const handleClose = () => {
         setSearchQuery('');
@@ -51,7 +44,6 @@ export const VersionSelector = ({ versions, isOpen, onClose }: Props) => {
     const selectVersion = (versionId: string) => {
         const nodeId = versions.find((v) => v.versionId === versionId)?.nodeId;
         if (nodeId) setSelectedContentId(nodeId);
-        updateContentUrl(selectedContentId ?? '', selectedLocale, versionId);
         setSelectedVersion(versionId);
         handleClose();
     };


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Oppdater URL-en kun ett sted, i Content.
- Fjern duplisert versjon i versjonsvelgeren.
- Fjern logikk for "Siste versjon" i åpne-knappen.
