### PR TITLE
Hold åpen versjonsvelger

### DIFF
--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -55,55 +55,64 @@ export const Content = () => {
         }
     }, [data, selectedContentId, selectedLocale, selectedVersion]);
 
-    // Calculate derived properties
-    const isWebpage = !!data?.html && !data?.json?.attachment;
-    const hasAttachment = !!data?.json?.attachment;
-
-    // State for view selector
-    const [selectedView, setSelectedView] = useState<ViewVariant | undefined>(() =>
+    const isWebpage = !!data?.html && !data.json.attachment;
+    const hasAttachment = !!data?.json.attachment;
+    const [selectedView, setSelectedView] = useState<ViewVariant | undefined>(
         getDefaultView(isWebpage, hasAttachment)
     );
 
-    // Update view when content type changes
-    useEffect(() => {
-        setSelectedView(getDefaultView(isWebpage, hasAttachment));
-    }, [isWebpage, hasAttachment, selectedContentId]);
+    const [versionSelectorCache, setVersionSelectorCache] = useState(() => {
+        const cache = getCachedVersionSelector(selectedContentId ?? '');
+        return {
+            component: cache.component,
+            versions: cache.versions,
+            isOpen: cache.isOpen,
+        };
+    });
 
-    // Single cache for content-related data
-    const [contentCache, setContentCache] = useState(() => ({
-        // Version selector
-        versions: getCachedVersionSelector(selectedContentId ?? '').versions,
-        versionComponent: getCachedVersionSelector(selectedContentId ?? '').component,
-        isVersionPanelOpen: getCachedVersionSelector(selectedContentId ?? '').isOpen,
-
-        // Display data
+    // Add this new state to cache display values
+    const [cachedDisplayData, setCachedDisplayData] = useState({
         displayName: '',
         path: '',
-    }));
+    });
 
-    // Update cache when content changes
+    // Update this useEffect to also cache display data when data loads
     useEffect(() => {
         if (prevContentIdRef.current && prevContentIdRef.current !== selectedContentId) {
             clearCachedVersionSelector(prevContentIdRef.current);
         }
 
         if (data?.versions && selectedContentId) {
-            setContentCache((prev) => ({
-                ...prev,
+            setVersionSelectorCache((prev) => ({
+                component: null,
                 versions: data.versions,
-                versionComponent: null,
-                displayName: data.json?.displayName || prev.displayName,
-                path: data.json?._path || prev.path,
+                isOpen: prev.isOpen,
             }));
+
+            // Cache display data when it's available
+            if (data.json?.displayName || data.json?._path) {
+                setCachedDisplayData({
+                    displayName: data.json.displayName || '',
+                    path: data.json._path || '',
+                });
+            }
         }
 
         prevContentIdRef.current = selectedContentId;
     }, [selectedContentId, data?.versions, data?.json]);
 
-    // Helper functions to get data with fallbacks
+    useEffect(() => {
+        setSelectedView(getDefaultView(isWebpage, hasAttachment));
+    }, [isWebpage, hasAttachment, selectedContentId]);
+
+    const htmlPath = `${xpArchiveConfig.basePath}/html/${selectedContentId}/${selectedLocale}/${
+        data?.json._versionKey
+    }`;
+
     const getVersionDisplay = () => {
-        if (selectedVersion && contentCache.versions.length > 0) {
-            const cachedVersion = contentCache.versions.find(
+        // First check if we have the version in our cache
+        if (selectedVersion && versionSelectorCache.versions.length > 0) {
+            const cachedVersion = versionSelectorCache.versions.find(
                 (v) => v.versionId === selectedVersion
             );
             if (cachedVersion?.timestamp) {
@@ -111,21 +120,23 @@ export const Content = () => {
             }
         }
 
+        // Fall back to data if cache doesn't have it
         if (selectedVersion && data?.versions) {
             return formatTimestamp(
                 data.versions.find((v) => v.versionId === selectedVersion)?.timestamp ?? ''
             );
         }
-
         return 'Laster...';
     };
 
-    const getDisplayName = () => data?.json?.displayName || contentCache.displayName || 'Laster...';
-    const getPath = () => data?.json?._path || contentCache.path || '';
+    // Add helper functions to get title and URL with fallbacks
+    const getDisplayName = () => {
+        return data?.json.displayName || cachedDisplayData.displayName || 'Laster...';
+    };
 
-    const htmlPath = `${xpArchiveConfig.basePath}/html/${selectedContentId}/${selectedLocale}/${
-        data?.json._versionKey
-    }`;
+    const getPath = () => {
+        return data?.json._path || cachedDisplayData.path || '';
+    };
 
     if (!selectedContentId) {
         return <EmptyState />;
@@ -143,45 +154,40 @@ export const Content = () => {
                             icon={<SidebarRightIcon />}
                             iconPosition={'right'}
                             onClick={() => {
-                                setContentCache((prev) => ({
+                                setVersionSelectorCache((prev) => ({
                                     ...prev,
-                                    isVersionPanelOpen: true,
+                                    isOpen: true,
                                 }));
                             }}
                         >
                             {getVersionDisplay()}
                         </Button>
 
-                        {contentCache.versionComponent ? (
-                            contentCache.versionComponent
+                        {versionSelectorCache.component ? (
+                            versionSelectorCache.component
                         ) : (
                             <VersionSelector
                                 versions={
-                                    contentCache.versions.length > 0
-                                        ? contentCache.versions
+                                    versionSelectorCache.versions.length > 0
+                                        ? versionSelectorCache.versions
                                         : data?.versions || []
                                 }
-                                isOpen={contentCache.isVersionPanelOpen}
+                                isOpen={versionSelectorCache.isOpen}
                                 onClose={() => {
-                                    setContentCache((prev) => ({
+                                    setVersionSelectorCache((prev) => ({
                                         ...prev,
-                                        isVersionPanelOpen: false,
+                                        isOpen: false,
                                     }));
                                 }}
                                 onMount={(component) => {
                                     setCachedVersionSelector(
                                         selectedContentId ?? '',
                                         component,
-                                        contentCache.versions.length > 0
-                                            ? contentCache.versions
+                                        versionSelectorCache.versions.length > 0
+                                            ? versionSelectorCache.versions
                                             : data?.versions || [],
-                                        contentCache.isVersionPanelOpen
+                                        versionSelectorCache.isOpen
                                     );
-
-                                    setContentCache((prev) => ({
-                                        ...prev,
-                                        versionComponent: component,
-                                    }));
                                 }}
                             />
                         )}

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -61,9 +61,8 @@ export const Content = () => {
         getDefaultView(isWebpage, hasAttachment)
     );
 
-    // Get cached state or initialize
     const [versionSelectorCache, setVersionSelectorCache] = useState(() => {
-        const cache = getCachedVersionSelector(selectedContentId || '');
+        const cache = getCachedVersionSelector(selectedContentId ?? '');
         return {
             component: cache.component,
             versions: cache.versions,
@@ -71,7 +70,6 @@ export const Content = () => {
         };
     });
 
-    // Update cache when content ID changes or new versions arrive
     useEffect(() => {
         if (prevContentIdRef.current && prevContentIdRef.current !== selectedContentId) {
             clearCachedVersionSelector(prevContentIdRef.current);
@@ -81,7 +79,7 @@ export const Content = () => {
             setVersionSelectorCache((prev) => ({
                 component: null,
                 versions: data.versions,
-                isOpen: prev.isOpen, // Always preserve open state
+                isOpen: prev.isOpen,
             }));
         }
 
@@ -130,7 +128,6 @@ export const Content = () => {
                             {getVersionDisplay()}
                         </Button>
 
-                        {/* Render either the cached component or a new VersionSelector */}
                         {versionSelectorCache.component ? (
                             versionSelectorCache.component
                         ) : (
@@ -148,9 +145,8 @@ export const Content = () => {
                                     }));
                                 }}
                                 onMount={(component) => {
-                                    // Cache the rendered component with the content ID
                                     setCachedVersionSelector(
-                                        selectedContentId || '',
+                                        selectedContentId ?? '',
                                         component,
                                         versionSelectorCache.versions.length > 0
                                             ? versionSelectorCache.versions

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -55,8 +55,8 @@ export const Content = () => {
         }
     }, [data, selectedContentId, selectedLocale, selectedVersion]);
 
-    const isWebpage = !!data?.html && !data.json.attachment;
-    const hasAttachment = !!data?.json.attachment;
+    const isWebpage = !!data?.html && !data?.json?.attachment;
+    const hasAttachment = !!data?.json?.attachment;
     const [selectedView, setSelectedView] = useState<ViewVariant | undefined>(
         getDefaultView(isWebpage, hasAttachment)
     );
@@ -131,11 +131,11 @@ export const Content = () => {
 
     // Add helper functions to get title and URL with fallbacks
     const getDisplayName = () => {
-        return data?.json.displayName || cachedDisplayData.displayName || 'Laster...';
+        return data?.json?.displayName || cachedDisplayData.displayName || 'Laster...';
     };
 
     const getPath = () => {
-        return data?.json._path || cachedDisplayData.path || '';
+        return data?.json?._path || cachedDisplayData.path || '';
     };
 
     if (!selectedContentId) {

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -23,9 +23,6 @@ const getDefaultView = (isWebpage: boolean, hasAttachment: boolean): ViewVariant
     return undefined;
 };
 
-// Storage key for persisting version selector state
-const STORAGE_KEY = 'versionSelector_state';
-
 export const Content = () => {
     const { selectedContentId, selectedLocale, selectedVersion, setSelectedVersion } =
         useAppState();

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -95,6 +95,17 @@ export const Content = () => {
     }`;
 
     const getVersionDisplay = () => {
+        // First check if we have the version in our cache
+        if (selectedVersion && versionSelectorCache.versions.length > 0) {
+            const cachedVersion = versionSelectorCache.versions.find(
+                (v) => v.versionId === selectedVersion
+            );
+            if (cachedVersion?.timestamp) {
+                return formatTimestamp(cachedVersion.timestamp);
+            }
+        }
+
+        // Fall back to data if cache doesn't have it
         if (selectedVersion && data?.versions) {
             return formatTimestamp(
                 data.versions.find((v) => v.versionId === selectedVersion)?.timestamp ?? ''

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -51,7 +51,7 @@ export const Content = () => {
                 setSelectedVersion(versionId);
             }
             const newUrl = `${xpArchiveConfig.basePath}/${selectedContentId}/${selectedLocale}/${versionId}`;
-            window.history.replaceState({}, '', newUrl);
+            window.history.pushState({}, '', newUrl);
         }
     }, [data, selectedContentId, selectedLocale, selectedVersion]);
 

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -157,34 +157,39 @@ export const Content = () => {
                             {getVersionDisplay()}
                         </Button>
 
-                        {versionSelectorCache.component ? (
-                            versionSelectorCache.component
-                        ) : (
-                            <VersionSelector
-                                versions={
-                                    versionSelectorCache.versions.length > 0
-                                        ? versionSelectorCache.versions
-                                        : data?.versions || []
-                                }
-                                isOpen={versionSelectorCache.isOpen}
-                                onClose={() => {
-                                    setVersionSelectorCache((prev) => ({
-                                        ...prev,
-                                        isOpen: false,
-                                    }));
-                                }}
-                                onMount={(component) => {
-                                    setCachedVersionSelector(
-                                        selectedContentId ?? '',
-                                        component,
-                                        versionSelectorCache.versions.length > 0
-                                            ? versionSelectorCache.versions
-                                            : data?.versions || [],
-                                        versionSelectorCache.isOpen
-                                    );
-                                }}
-                            />
-                        )}
+                        {versionSelectorCache.component
+                            ? versionSelectorCache.component
+                            : (() => {
+                                  const versionSelectorVersions =
+                                      versionSelectorCache.versions.length > 0
+                                          ? versionSelectorCache.versions
+                                          : data?.versions || [];
+
+                                  const handleClose = () => {
+                                      setVersionSelectorCache((prev) => ({
+                                          ...prev,
+                                          isOpen: false,
+                                      }));
+                                  };
+
+                                  const handleMount = (component: React.ReactNode) => {
+                                      setCachedVersionSelector(
+                                          selectedContentId ?? '',
+                                          component,
+                                          versionSelectorVersions,
+                                          versionSelectorCache.isOpen
+                                      );
+                                  };
+
+                                  return (
+                                      <VersionSelector
+                                          versions={versionSelectorVersions}
+                                          isOpen={versionSelectorCache.isOpen}
+                                          onClose={handleClose}
+                                          onMount={handleMount}
+                                      />
+                                  );
+                              })()}
                     </div>
                     <div className={style.viewSelector}>
                         <Label className={style.label}>Visning</Label>

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -70,6 +70,13 @@ export const Content = () => {
         };
     });
 
+    // Add this new state to cache display values
+    const [cachedDisplayData, setCachedDisplayData] = useState({
+        displayName: '',
+        path: '',
+    });
+
+    // Update this useEffect to also cache display data when data loads
     useEffect(() => {
         if (prevContentIdRef.current && prevContentIdRef.current !== selectedContentId) {
             clearCachedVersionSelector(prevContentIdRef.current);
@@ -81,10 +88,18 @@ export const Content = () => {
                 versions: data.versions,
                 isOpen: prev.isOpen,
             }));
+
+            // Cache display data when it's available
+            if (data.json?.displayName || data.json?._path) {
+                setCachedDisplayData({
+                    displayName: data.json.displayName || '',
+                    path: data.json._path || '',
+                });
+            }
         }
 
         prevContentIdRef.current = selectedContentId;
-    }, [selectedContentId, data?.versions]);
+    }, [selectedContentId, data?.versions, data?.json]);
 
     useEffect(() => {
         setSelectedView(getDefaultView(isWebpage, hasAttachment));
@@ -112,6 +127,15 @@ export const Content = () => {
             );
         }
         return 'Laster...';
+    };
+
+    // Add helper functions to get title and URL with fallbacks
+    const getDisplayName = () => {
+        return data?.json.displayName || cachedDisplayData.displayName || 'Laster...';
+    };
+
+    const getPath = () => {
+        return data?.json._path || cachedDisplayData.path || '';
     };
 
     if (!selectedContentId) {
@@ -195,10 +219,10 @@ export const Content = () => {
 
                 <div className={style.titleAndUrl}>
                     <Heading size={'medium'} level={'2'}>
-                        {data?.json.displayName ?? ''}
+                        {getDisplayName()}
                     </Heading>
                     <div className={style.url}>
-                        <Detail>{data?.json._path ?? ''}</Detail>
+                        <Detail>{getPath()}</Detail>
                     </div>
                 </div>
             </div>

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -71,34 +71,22 @@ export const Content = () => {
         };
     });
 
-    // Update this effect to clear the cache immediately when content ID changes
+    // Update cache when content ID changes or new versions arrive
     useEffect(() => {
-        // Clear the cache for the previous content ID when it changes
         if (prevContentIdRef.current && prevContentIdRef.current !== selectedContentId) {
             clearCachedVersionSelector(prevContentIdRef.current);
         }
 
-        prevContentIdRef.current = selectedContentId;
-
-        // Also reset the local cache state when content ID changes, but preserve isOpen state
         if (data?.versions && selectedContentId) {
             setVersionSelectorCache((prev) => ({
                 component: null,
                 versions: data.versions,
-                isOpen: prev.isOpen, // Preserve the open state
+                isOpen: prev.isOpen, // Always preserve open state
             }));
         }
-    }, [selectedContentId, data?.versions]);
 
-    // Add a separate effect to handle data loading without affecting panel state
-    useEffect(() => {
-        if (data?.versions && selectedContentId) {
-            setVersionSelectorCache((prev) => ({
-                ...prev,
-                versions: data.versions,
-            }));
-        }
-    }, [data?.versions, selectedContentId]);
+        prevContentIdRef.current = selectedContentId;
+    }, [selectedContentId, data?.versions]);
 
     useEffect(() => {
         setSelectedView(getDefaultView(isWebpage, hasAttachment));

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -30,6 +30,8 @@ export const Content = () => {
     const { selectedContentId, selectedLocale, selectedVersion, setSelectedVersion } =
         useAppState();
 
+    const prevContentIdRef = React.useRef(selectedContentId);
+
     useEffect(() => {
         const pathSegments = window.location.pathname.split('/');
         if (pathSegments.length >= 5) {
@@ -76,13 +78,11 @@ export const Content = () => {
     // Update this effect to clear the cache immediately when content ID changes
     useEffect(() => {
         // Clear the cache for the previous content ID when it changes
-        const prevContentId = React.useRef(selectedContentId);
-
-        if (prevContentId.current && prevContentId.current !== selectedContentId) {
-            clearCachedVersionSelector(prevContentId.current);
+        if (prevContentIdRef.current && prevContentIdRef.current !== selectedContentId) {
+            clearCachedVersionSelector(prevContentIdRef.current);
         }
 
-        prevContentId.current = selectedContentId;
+        prevContentIdRef.current = selectedContentId;
 
         // Also reset the local cache state when content ID changes
         if (data?.versions && selectedContentId) {

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -84,15 +84,25 @@ export const Content = () => {
 
         prevContentIdRef.current = selectedContentId;
 
-        // Also reset the local cache state when content ID changes
+        // Also reset the local cache state when content ID changes, but preserve isOpen state
         if (data?.versions && selectedContentId) {
-            setVersionSelectorCache({
+            setVersionSelectorCache((prev) => ({
                 component: null,
                 versions: data.versions,
-                isOpen: false,
-            });
+                isOpen: prev.isOpen, // Preserve the open state
+            }));
         }
     }, [selectedContentId, data?.versions]);
+
+    // Add a separate effect to handle data loading without affecting panel state
+    useEffect(() => {
+        if (data?.versions && selectedContentId) {
+            setVersionSelectorCache((prev) => ({
+                ...prev,
+                versions: data.versions,
+            }));
+        }
+    }, [data?.versions, selectedContentId]);
 
     useEffect(() => {
         setSelectedView(getDefaultView(isWebpage, hasAttachment));

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -70,14 +70,13 @@ export const Content = () => {
         };
     });
 
-    // Add view type to cached display data
+    // Add this new state to cache display values
     const [cachedDisplayData, setCachedDisplayData] = useState({
         displayName: '',
         path: '',
-        view: undefined as ViewVariant | undefined,
     });
 
-    // Update this useEffect to also cache display data and view when data loads
+    // Update this useEffect to also cache display data when data loads
     useEffect(() => {
         if (prevContentIdRef.current && prevContentIdRef.current !== selectedContentId) {
             clearCachedVersionSelector(prevContentIdRef.current);
@@ -92,39 +91,19 @@ export const Content = () => {
 
             // Cache display data when it's available
             if (data.json?.displayName || data.json?._path) {
-                setCachedDisplayData((prev) => ({
-                    displayName: data.json?.displayName || '',
-                    path: data.json?._path || '',
-                    view: prev.view, // Keep existing view
-                }));
+                setCachedDisplayData({
+                    displayName: data.json.displayName || '',
+                    path: data.json._path || '',
+                });
             }
         }
 
         prevContentIdRef.current = selectedContentId;
     }, [selectedContentId, data?.versions, data?.json]);
 
-    // Update view selector effect to store the selected view in cache
     useEffect(() => {
-        const newView = getDefaultView(isWebpage, hasAttachment);
-        setSelectedView(newView);
-
-        // Cache the view
-        setCachedDisplayData((prev) => ({
-            ...prev,
-            view: newView,
-        }));
+        setSelectedView(getDefaultView(isWebpage, hasAttachment));
     }, [isWebpage, hasAttachment, selectedContentId]);
-
-    // Add handler to update cached view
-    const handleViewChange = (view: ViewVariant) => {
-        setSelectedView(view);
-
-        // Update cached view
-        setCachedDisplayData((prev) => ({
-            ...prev,
-            view,
-        }));
-    };
 
     const htmlPath = `${xpArchiveConfig.basePath}/html/${selectedContentId}/${selectedLocale}/${
         data?.json._versionKey
@@ -218,7 +197,7 @@ export const Content = () => {
                         <div className={style.viewSelectorWrapper}>
                             <ViewSelector
                                 selectedView={selectedView}
-                                setSelectedView={handleViewChange}
+                                setSelectedView={setSelectedView}
                                 hasAttachment={hasAttachment}
                                 isWebpage={isWebpage}
                             />

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -124,14 +124,6 @@ export const Content = () => {
         return 'Laster...';
     };
 
-    const getDisplayName = () => {
-        return data?.json?.displayName || cachedDisplayData.displayName || 'Laster...';
-    };
-
-    const getPath = () => {
-        return data?.json?._path || cachedDisplayData.path || '';
-    };
-
     if (!selectedContentId) {
         return <EmptyState />;
     }
@@ -218,10 +210,10 @@ export const Content = () => {
 
                 <div className={style.titleAndUrl}>
                     <Heading size={'medium'} level={'2'}>
-                        {getDisplayName()}
+                        {data?.json?.displayName || cachedDisplayData.displayName || 'Laster...'}
                     </Heading>
                     <div className={style.url}>
-                        <Detail>{getPath()}</Detail>
+                        <Detail>{data?.json?._path || cachedDisplayData.path || ''}</Detail>
                     </div>
                 </div>
             </div>

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -146,8 +146,10 @@ export const Content = () => {
                             {getVersionDisplay()}
                         </Button>
 
-                        {/* Use the cached component if available */}
-                        {versionSelectorCache.component || (
+                        {/* Render either the cached component or a new VersionSelector */}
+                        {versionSelectorCache.component ? (
+                            versionSelectorCache.component
+                        ) : (
                             <VersionSelector
                                 versions={
                                     versionSelectorCache.versions.length > 0

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -44,16 +44,16 @@ export const Content = () => {
         versionId: selectedVersion ?? '',
     });
 
+    // Simplified version ID and URL handling
     useEffect(() => {
-        const versionId = selectedVersion ?? data?.versions?.[0]?.versionId;
-        if (versionId) {
-            if (!selectedVersion) {
-                setSelectedVersion(versionId);
-            }
-            const newUrl = `${xpArchiveConfig.basePath}/${selectedContentId}/${selectedLocale}/${versionId}`;
+        if (!selectedVersion && data?.versions?.[0]) {
+            setSelectedVersion(data.versions[0].versionId);
+        }
+        if (selectedContentId && selectedLocale && selectedVersion) {
+            const newUrl = `${xpArchiveConfig.basePath}/${selectedContentId}/${selectedLocale}/${selectedVersion}`;
             window.history.replaceState({}, '', newUrl);
         }
-    }, [data, selectedContentId, selectedLocale, selectedVersion]);
+    }, [data?.versions, selectedContentId, selectedLocale, selectedVersion]);
 
     const isWebpage = !!data?.html && !data.json.attachment;
     const hasAttachment = !!data?.json.attachment;
@@ -71,7 +71,7 @@ export const Content = () => {
         };
     });
 
-    // Update cache when content ID changes or new versions arrive
+    // Single effect for cache management
     useEffect(() => {
         if (prevContentIdRef.current && prevContentIdRef.current !== selectedContentId) {
             clearCachedVersionSelector(prevContentIdRef.current);
@@ -81,7 +81,7 @@ export const Content = () => {
             setVersionSelectorCache((prev) => ({
                 component: null,
                 versions: data.versions,
-                isOpen: prev.isOpen, // Always preserve open state
+                isOpen: prev.isOpen,
             }));
         }
 
@@ -130,16 +130,11 @@ export const Content = () => {
                             {getVersionDisplay()}
                         </Button>
 
-                        {/* Render either the cached component or a new VersionSelector */}
                         {versionSelectorCache.component ? (
                             versionSelectorCache.component
                         ) : (
                             <VersionSelector
-                                versions={
-                                    versionSelectorCache.versions.length > 0
-                                        ? versionSelectorCache.versions
-                                        : data?.versions || []
-                                }
+                                versions={data?.versions || []}
                                 isOpen={versionSelectorCache.isOpen}
                                 onClose={() => {
                                     setVersionSelectorCache((prev) => ({
@@ -148,13 +143,10 @@ export const Content = () => {
                                     }));
                                 }}
                                 onMount={(component) => {
-                                    // Cache the rendered component with the content ID
                                     setCachedVersionSelector(
                                         selectedContentId || '',
                                         component,
-                                        versionSelectorCache.versions.length > 0
-                                            ? versionSelectorCache.versions
-                                            : data?.versions || [],
+                                        data?.versions || [],
                                         versionSelectorCache.isOpen
                                     );
                                 }}

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '@common/shared/EmptyState/EmptyState';
 import {
     setCachedVersionSelector,
     getCachedVersionSelector,
+    clearCachedVersionSelector,
 } from 'client/versionSelector/VersionSelectorCache';
 
 import style from './Content.module.css';
@@ -64,13 +65,23 @@ export const Content = () => {
 
     // Get cached state or initialize
     const [versionSelectorCache, setVersionSelectorCache] = useState(() => {
-        const cache = getCachedVersionSelector();
+        const cache = getCachedVersionSelector(selectedContentId || '');
         return {
             component: cache.component,
             versions: cache.versions,
             isOpen: cache.isOpen,
         };
     });
+
+    // Clear cache when content changes
+    useEffect(() => {
+        // When content ID changes, reset the cache for the previous content
+        return () => {
+            if (selectedContentId) {
+                clearCachedVersionSelector(selectedContentId);
+            }
+        };
+    }, [selectedContentId]);
 
     // Update the cache when versions change
     useEffect(() => {
@@ -143,8 +154,9 @@ export const Content = () => {
                                     }));
                                 }}
                                 onMount={(component) => {
-                                    // Cache the rendered component
+                                    // Cache the rendered component with the content ID
                                     setCachedVersionSelector(
+                                        selectedContentId || '',
                                         component,
                                         versionSelectorCache.versions.length > 0
                                             ? versionSelectorCache.versions

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -73,28 +73,26 @@ export const Content = () => {
         };
     });
 
-    // Clear cache when content changes
+    // Update this effect to clear the cache immediately when content ID changes
     useEffect(() => {
-        // When content ID changes, reset the cache for the previous content
-        return () => {
-            if (selectedContentId) {
-                clearCachedVersionSelector(selectedContentId);
-            }
-        };
-    }, [selectedContentId]);
+        // Clear the cache for the previous content ID when it changes
+        const prevContentId = React.useRef(selectedContentId);
 
-    // Update the cache when versions change
-    useEffect(() => {
-        if (data?.versions && data.versions.length > 0) {
-            // Only update versions in cache if we don't have any yet
-            if (versionSelectorCache.versions.length === 0) {
-                setVersionSelectorCache((prev) => ({
-                    ...prev,
-                    versions: data.versions,
-                }));
-            }
+        if (prevContentId.current && prevContentId.current !== selectedContentId) {
+            clearCachedVersionSelector(prevContentId.current);
         }
-    }, [data?.versions]);
+
+        prevContentId.current = selectedContentId;
+
+        // Also reset the local cache state when content ID changes
+        if (data?.versions && selectedContentId) {
+            setVersionSelectorCache({
+                component: null,
+                versions: data.versions,
+                isOpen: false,
+            });
+        }
+    }, [selectedContentId, data?.versions]);
 
     useEffect(() => {
         setSelectedView(getDefaultView(isWebpage, hasAttachment));

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -70,13 +70,11 @@ export const Content = () => {
         };
     });
 
-    // Add this new state to cache display values
     const [cachedDisplayData, setCachedDisplayData] = useState({
         displayName: '',
         path: '',
     });
 
-    // Update this useEffect to also cache display data when data loads
     useEffect(() => {
         if (prevContentIdRef.current && prevContentIdRef.current !== selectedContentId) {
             clearCachedVersionSelector(prevContentIdRef.current);
@@ -89,7 +87,6 @@ export const Content = () => {
                 isOpen: prev.isOpen,
             }));
 
-            // Cache display data when it's available
             if (data.json?.displayName || data.json?._path) {
                 setCachedDisplayData({
                     displayName: data.json.displayName || '',
@@ -110,7 +107,6 @@ export const Content = () => {
     }`;
 
     const getVersionDisplay = () => {
-        // First check if we have the version in our cache
         if (selectedVersion && versionSelectorCache.versions.length > 0) {
             const cachedVersion = versionSelectorCache.versions.find(
                 (v) => v.versionId === selectedVersion
@@ -120,7 +116,6 @@ export const Content = () => {
             }
         }
 
-        // Fall back to data if cache doesn't have it
         if (selectedVersion && data?.versions) {
             return formatTimestamp(
                 data.versions.find((v) => v.versionId === selectedVersion)?.timestamp ?? ''
@@ -129,7 +124,6 @@ export const Content = () => {
         return 'Laster...';
     };
 
-    // Add helper functions to get title and URL with fallbacks
     const getDisplayName = () => {
         return data?.json?.displayName || cachedDisplayData.displayName || 'Laster...';
     };

--- a/xp-archive/client/content/Content.tsx
+++ b/xp-archive/client/content/Content.tsx
@@ -48,13 +48,12 @@ export const Content = () => {
     });
 
     useEffect(() => {
-        if (selectedVersion) {
-            const newUrl = `${xpArchiveConfig.basePath}/${selectedContentId}/${selectedLocale}/${selectedVersion}`;
-            window.history.replaceState({}, '', newUrl);
-        } else if (data?.versions?.[0]) {
-            const latestVersionId = data.versions[0].versionId;
-            setSelectedVersion(latestVersionId);
-            const newUrl = `${xpArchiveConfig.basePath}/${selectedContentId}/${selectedLocale}/${latestVersionId}`;
+        const versionId = selectedVersion ?? data?.versions?.[0]?.versionId;
+        if (versionId) {
+            if (!selectedVersion) {
+                setSelectedVersion(versionId);
+            }
+            const newUrl = `${xpArchiveConfig.basePath}/${selectedContentId}/${selectedLocale}/${versionId}`;
             window.history.replaceState({}, '', newUrl);
         }
     }, [data, selectedContentId, selectedLocale, selectedVersion]);

--- a/xp-archive/client/versionSelector/SlidePanel/SlidePanel.module.css
+++ b/xp-archive/client/versionSelector/SlidePanel/SlidePanel.module.css
@@ -19,7 +19,7 @@
 .panel {
     position: relative;
     z-index: 1;
-    width: 400px;
+    width: 460px;
     height: 100vh;
     background: var(--a-surface-default);
     box-shadow: 4px 0 8px rgba(0, 0, 0, 0.1);

--- a/xp-archive/client/versionSelector/SlidePanel/SlidePanel.module.css
+++ b/xp-archive/client/versionSelector/SlidePanel/SlidePanel.module.css
@@ -17,6 +17,8 @@
 }
 
 .panel {
+    display: flex;
+    flex-direction: column;
     position: relative;
     z-index: 1;
     width: 460px;

--- a/xp-archive/client/versionSelector/VersionSelector.module.css
+++ b/xp-archive/client/versionSelector/VersionSelector.module.css
@@ -40,3 +40,14 @@
         font-weight: var(--a-font-weight-bold);
     }
 }
+
+.closeButton {
+    position: sticky;
+    bottom: 1rem;
+    margin-top: 1.75rem;
+
+    width: fit-content;
+    border-radius: 99px;
+    background-color: var(--a-surface-inverted);
+    align-self: center;
+}

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -140,6 +140,18 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
         }
     }, [versions, isOpen, searchQuery, selectedVersion]);
 
+    // Add a useEffect to update the filtered versions when the input versions change
+    useEffect(() => {
+        // Reset search query when versions change completely (different content)
+        if (
+            versions.length > 0 &&
+            filteredVersions.length > 0 &&
+            versions[0].nodeId !== filteredVersions[0].nodeId
+        ) {
+            setSearchQuery('');
+        }
+    }, [versions]);
+
     // Return the same component
     return (
         <SlidePanel isOpen={isOpen} onClose={handleClose}>

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -12,6 +12,7 @@ type Props = {
     versions: VersionReference[];
     isOpen: boolean;
     onClose: () => void;
+    onMount?: (component: React.ReactNode) => void;
 };
 
 type VersionButtonProps = {
@@ -35,7 +36,7 @@ const VersionButton = ({ isSelected, onClick, children }: VersionButtonProps) =>
 // Storage key for persisting version selector state
 const STORAGE_KEY = 'versionSelector_state';
 
-export const VersionSelector = ({ versions, isOpen, onClose }: Props) => {
+export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) => {
     const [searchQuery, setSearchQuery] = useState('');
     const { setSelectedContentId, selectedVersion, setSelectedVersion } = useAppState();
 
@@ -102,6 +103,42 @@ export const VersionSelector = ({ versions, isOpen, onClose }: Props) => {
         formatTimestamp(version.timestamp).toLowerCase().includes(searchQuery.toLowerCase())
     );
 
+    // Call onMount with the rendered component
+    useEffect(() => {
+        if (onMount) {
+            const component = (
+                <SlidePanel isOpen={isOpen} onClose={handleClose}>
+                    <Heading size="medium" spacing>
+                        Versjoner
+                    </Heading>
+                    <Search
+                        label="Søk i versjoner"
+                        variant="simple"
+                        value={searchQuery}
+                        onChange={setSearchQuery}
+                        className={style.search}
+                    />
+                    <div className={style.versionList}>
+                        {filteredVersions.map((version, index) => (
+                            <VersionButton
+                                key={version.versionId}
+                                isSelected={version.versionId === selectedVersion}
+                                onClick={() => selectVersion(version.versionId)}
+                            >
+                                {formatTimestamp(version.timestamp)}
+                                {index === 0 && (
+                                    <span style={{ fontWeight: 'normal' }}> (Siste versjon)</span>
+                                )}
+                            </VersionButton>
+                        ))}
+                    </div>
+                </SlidePanel>
+            );
+            onMount(component);
+        }
+    }, [versions, isOpen, searchQuery, selectedVersion]);
+
+    // Return the same component
     return (
         <SlidePanel isOpen={isOpen} onClose={handleClose}>
             <Heading size="medium" spacing>

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -33,51 +33,11 @@ const VersionButton = ({ isSelected, onClick, children }: VersionButtonProps) =>
     </Button>
 );
 
-// Storage key for persisting version selector state
-const getStorageKey = (contentId: string) => `versionSelector_state_${contentId}`;
-
 export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) => {
     const [searchQuery, setSearchQuery] = useState('');
-    const { setSelectedContentId, selectedVersion, setSelectedVersion, selectedContentId } =
-        useAppState();
-    const storageKey = getStorageKey(selectedContentId || '');
-
-    // Load search query from localStorage on mount
-    useEffect(() => {
-        if (isOpen) {
-            try {
-                const savedState = localStorage.getItem(storageKey);
-                if (savedState) {
-                    const { searchQuery: savedQuery } = JSON.parse(savedState);
-                    if (savedQuery) {
-                        setSearchQuery(savedQuery);
-                    }
-                }
-            } catch (e) {
-                console.error('Failed to load version selector state', e);
-            }
-        }
-    }, [isOpen, storageKey]);
-
-    // Save state to localStorage when it changes
-    useEffect(() => {
-        if (isOpen) {
-            try {
-                localStorage.setItem(
-                    storageKey,
-                    JSON.stringify({
-                        searchQuery,
-                        selectedVersion,
-                    })
-                );
-            } catch (e) {
-                console.error('Failed to save version selector state', e);
-            }
-        }
-    }, [isOpen, searchQuery, selectedVersion, storageKey]);
+    const { setSelectedContentId, selectedVersion, setSelectedVersion } = useAppState();
 
     const handleClose = () => {
-        // Don't clear search query when closing
         onClose();
     };
 
@@ -85,20 +45,6 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
         const nodeId = versions.find((v) => v.versionId === versionId)?.nodeId;
         if (nodeId) setSelectedContentId(nodeId);
         setSelectedVersion(versionId);
-
-        // Save selected version to localStorage
-        try {
-            localStorage.setItem(
-                storageKey,
-                JSON.stringify({
-                    searchQuery,
-                    selectedVersion: versionId,
-                    keepOpen: true, // Flag to keep panel open
-                })
-            );
-        } catch (e) {
-            console.error('Failed to save version selection', e);
-        }
     };
 
     const filteredVersions = versions.filter((version) =>

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -51,44 +51,8 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
         formatTimestamp(version.timestamp).toLowerCase().includes(searchQuery.toLowerCase())
     );
 
-    // Call onMount with the rendered component
+    // Reset search when versions change completely
     useEffect(() => {
-        if (onMount) {
-            const component = (
-                <SlidePanel isOpen={isOpen} onClose={handleClose}>
-                    <Heading size="medium" spacing>
-                        Versjoner
-                    </Heading>
-                    <Search
-                        label="Søk i versjoner"
-                        variant="simple"
-                        value={searchQuery}
-                        onChange={setSearchQuery}
-                        className={style.search}
-                    />
-                    <div className={style.versionList}>
-                        {filteredVersions.map((version, index) => (
-                            <VersionButton
-                                key={version.versionId}
-                                isSelected={version.versionId === selectedVersion}
-                                onClick={() => selectVersion(version.versionId)}
-                            >
-                                {formatTimestamp(version.timestamp)}
-                                {index === 0 && (
-                                    <span style={{ fontWeight: 'normal' }}> (Siste versjon)</span>
-                                )}
-                            </VersionButton>
-                        ))}
-                    </div>
-                </SlidePanel>
-            );
-            onMount(component);
-        }
-    }, [versions, isOpen, searchQuery, selectedVersion]);
-
-    // Add a useEffect to update the filtered versions when the input versions change
-    useEffect(() => {
-        // Reset search query when versions change completely (different content)
         if (
             versions.length > 0 &&
             filteredVersions.length > 0 &&
@@ -98,8 +62,7 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
         }
     }, [versions]);
 
-    // Return the same component
-    return (
+    const component = (
         <SlidePanel isOpen={isOpen} onClose={handleClose}>
             <Heading size="medium" spacing>
                 Versjoner
@@ -127,4 +90,13 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
             </div>
         </SlidePanel>
     );
+
+    // Call onMount with the component
+    useEffect(() => {
+        if (onMount) {
+            onMount(component);
+        }
+    }, [versions, isOpen, searchQuery, selectedVersion]);
+
+    return component;
 };

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { CheckmarkIcon, XMarkIcon } from '@navikt/aksel-icons';
 import { Heading, Button, Search } from '@navikt/ds-react';
 import { VersionReference } from 'shared/types';
 import { formatTimestamp } from '@common/shared/timestamp';
@@ -6,7 +7,6 @@ import { useAppState } from 'client/context/appState/useAppState';
 import { SlidePanel } from './SlidePanel/SlidePanel';
 import { classNames } from '@common/client/utils/classNames';
 import style from './VersionSelector.module.css';
-import { CheckmarkIcon } from '@navikt/aksel-icons';
 
 type Props = {
     versions: VersionReference[];
@@ -87,6 +87,14 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
                     </VersionButton>
                 ))}
             </div>
+            <Button
+                className={style.closeButton}
+                variant="primary-neutral"
+                icon={<XMarkIcon />}
+                onClick={handleClose}
+            >
+                Lukk versjonsvelger
+            </Button>
         </SlidePanel>
     );
 

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -38,6 +38,7 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
     const { setSelectedContentId, selectedVersion, setSelectedVersion } = useAppState();
 
     const handleClose = () => {
+        setSearchQuery('');
         onClose();
     };
 
@@ -50,16 +51,6 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
     const filteredVersions = versions.filter((version) =>
         formatTimestamp(version.timestamp).toLowerCase().includes(searchQuery.toLowerCase())
     );
-
-    useEffect(() => {
-        if (
-            versions.length > 0 &&
-            filteredVersions.length > 0 &&
-            versions[0].nodeId !== filteredVersions[0].nodeId
-        ) {
-            setSearchQuery('');
-        }
-    }, [versions]);
 
     const component = (
         <SlidePanel isOpen={isOpen} onClose={handleClose}>

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -34,17 +34,19 @@ const VersionButton = ({ isSelected, onClick, children }: VersionButtonProps) =>
 );
 
 // Storage key for persisting version selector state
-const STORAGE_KEY = 'versionSelector_state';
+const getStorageKey = (contentId: string) => `versionSelector_state_${contentId}`;
 
 export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) => {
     const [searchQuery, setSearchQuery] = useState('');
-    const { setSelectedContentId, selectedVersion, setSelectedVersion } = useAppState();
+    const { setSelectedContentId, selectedVersion, setSelectedVersion, selectedContentId } =
+        useAppState();
+    const storageKey = getStorageKey(selectedContentId || '');
 
     // Load search query from localStorage on mount
     useEffect(() => {
         if (isOpen) {
             try {
-                const savedState = localStorage.getItem(STORAGE_KEY);
+                const savedState = localStorage.getItem(storageKey);
                 if (savedState) {
                     const { searchQuery: savedQuery } = JSON.parse(savedState);
                     if (savedQuery) {
@@ -55,14 +57,14 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
                 console.error('Failed to load version selector state', e);
             }
         }
-    }, [isOpen]);
+    }, [isOpen, storageKey]);
 
     // Save state to localStorage when it changes
     useEffect(() => {
         if (isOpen) {
             try {
                 localStorage.setItem(
-                    STORAGE_KEY,
+                    storageKey,
                     JSON.stringify({
                         searchQuery,
                         selectedVersion,
@@ -72,7 +74,7 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
                 console.error('Failed to save version selector state', e);
             }
         }
-    }, [isOpen, searchQuery, selectedVersion]);
+    }, [isOpen, searchQuery, selectedVersion, storageKey]);
 
     const handleClose = () => {
         // Don't clear search query when closing
@@ -87,7 +89,7 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
         // Save selected version to localStorage
         try {
             localStorage.setItem(
-                STORAGE_KEY,
+                storageKey,
                 JSON.stringify({
                     searchQuery,
                     selectedVersion: versionId,

--- a/xp-archive/client/versionSelector/VersionSelector.tsx
+++ b/xp-archive/client/versionSelector/VersionSelector.tsx
@@ -51,7 +51,6 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
         formatTimestamp(version.timestamp).toLowerCase().includes(searchQuery.toLowerCase())
     );
 
-    // Reset search when versions change completely
     useEffect(() => {
         if (
             versions.length > 0 &&
@@ -91,7 +90,6 @@ export const VersionSelector = ({ versions, isOpen, onClose, onMount }: Props) =
         </SlidePanel>
     );
 
-    // Call onMount with the component
     useEffect(() => {
         if (onMount) {
             onMount(component);

--- a/xp-archive/client/versionSelector/VersionSelectorCache.tsx
+++ b/xp-archive/client/versionSelector/VersionSelectorCache.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import { VersionReference } from 'shared/types';
 
-const contentCache: Record<
-    string,
-    {
-        component: React.ReactNode | null;
-        versions: VersionReference[];
-        isOpen: boolean;
-    }
-> = {};
+type VersionSelectorCacheItem = {
+    component: React.ReactNode | null;
+    versions: VersionReference[];
+    isOpen: boolean;
+};
+
+const DEFAULT_CACHE: VersionSelectorCacheItem = {
+    component: null,
+    versions: [],
+    isOpen: false,
+};
+
+const contentCache: Record<string, VersionSelectorCacheItem> = {};
 
 export const setCachedVersionSelector = (
     contentId: string,
@@ -29,17 +34,11 @@ export const setCachedVersionSelector = (
     };
 };
 
-export const getCachedVersionSelector = (contentId: string) => {
-    return (
-        contentCache[contentId] || {
-            component: null,
-            versions: [],
-            isOpen: false,
-        }
-    );
+export const getCachedVersionSelector = (contentId: string): VersionSelectorCacheItem => {
+    return contentCache[contentId] || DEFAULT_CACHE;
 };
 
-export const clearCachedVersionSelector = (contentId: string) => {
+export const clearCachedVersionSelector = (contentId: string): void => {
     if (contentId in contentCache) {
         delete contentCache[contentId];
     }

--- a/xp-archive/client/versionSelector/VersionSelectorCache.tsx
+++ b/xp-archive/client/versionSelector/VersionSelectorCache.tsx
@@ -17,6 +17,13 @@ export const setCachedVersionSelector = (
     versions: VersionReference[],
     isOpen: boolean
 ) => {
+    // Clear all other caches first to prevent stale data
+    Object.keys(contentCache).forEach((key) => {
+        if (key !== contentId) {
+            delete contentCache[key];
+        }
+    });
+
     contentCache[contentId] = {
         component,
         versions,

--- a/xp-archive/client/versionSelector/VersionSelectorCache.tsx
+++ b/xp-archive/client/versionSelector/VersionSelectorCache.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { VersionReference } from 'shared/types';
 
-// Content-specific cache for the version selector component
 const contentCache: Record<
     string,
     {
@@ -17,7 +16,6 @@ export const setCachedVersionSelector = (
     versions: VersionReference[],
     isOpen: boolean
 ) => {
-    // Clear all other caches first to prevent stale data
     Object.keys(contentCache).forEach((key) => {
         if (key !== contentId) {
             delete contentCache[key];

--- a/xp-archive/client/versionSelector/VersionSelectorCache.tsx
+++ b/xp-archive/client/versionSelector/VersionSelectorCache.tsx
@@ -1,23 +1,41 @@
 import React from 'react';
 import { VersionReference } from 'shared/types';
 
-// Global cache for the version selector component
-let cachedVersionSelector: React.ReactNode | null = null;
-let cachedVersions: VersionReference[] = [];
-let cachedIsOpen = false;
+// Content-specific cache for the version selector component
+const contentCache: Record<
+    string,
+    {
+        component: React.ReactNode | null;
+        versions: VersionReference[];
+        isOpen: boolean;
+    }
+> = {};
 
 export const setCachedVersionSelector = (
+    contentId: string,
     component: React.ReactNode,
     versions: VersionReference[],
     isOpen: boolean
 ) => {
-    cachedVersionSelector = component;
-    cachedVersions = versions;
-    cachedIsOpen = isOpen;
+    contentCache[contentId] = {
+        component,
+        versions,
+        isOpen,
+    };
 };
 
-export const getCachedVersionSelector = () => ({
-    component: cachedVersionSelector,
-    versions: cachedVersions,
-    isOpen: cachedIsOpen,
-});
+export const getCachedVersionSelector = (contentId: string) => {
+    return (
+        contentCache[contentId] || {
+            component: null,
+            versions: [],
+            isOpen: false,
+        }
+    );
+};
+
+export const clearCachedVersionSelector = (contentId: string) => {
+    if (contentId in contentCache) {
+        delete contentCache[contentId];
+    }
+};

--- a/xp-archive/client/versionSelector/VersionSelectorCache.tsx
+++ b/xp-archive/client/versionSelector/VersionSelectorCache.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { VersionReference } from 'shared/types';
+
+// Global cache for the version selector component
+let cachedVersionSelector: React.ReactNode | null = null;
+let cachedVersions: VersionReference[] = [];
+let cachedIsOpen = false;
+
+export const setCachedVersionSelector = (
+    component: React.ReactNode,
+    versions: VersionReference[],
+    isOpen: boolean
+) => {
+    cachedVersionSelector = component;
+    cachedVersions = versions;
+    cachedIsOpen = isOpen;
+};
+
+export const getCachedVersionSelector = () => ({
+    component: cachedVersionSelector,
+    versions: cachedVersions,
+    isOpen: cachedIsOpen,
+});


### PR DESCRIPTION
## Oppsummering av hva som er gjort

- Implementert caching-mekanisme for å hindre at versjonsvelgeren forsvinner/oppdateres når en versjon velges
- Optimalisert visning av tittel, URL og versjon ved å cache data som allerede er lastet
- Lagt til en lukk-knapp i versjonsvelgeren
